### PR TITLE
Update site and theme for second event

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,7 +23,7 @@ params:
   # Active sections on the website to deactivate comment out with '#'
   # you can also change order here and it will reflect on page
   Sections:
-    - promo
+    #- promo
     - about
     - events
     - committee
@@ -63,9 +63,8 @@ params:
   # Promo box items
   Promo:
     - text: >
-        Interested in R and Medicine? Join us at the R/Medicine conference, August 27 - 29, 2020. »
-      actionText: "Learn more"
-      actionURL: "https://events.linuxfoundation.org/r-medicine/"
+        This is a promotion »
+      actionURL: "https://r-consortium.org/"
 
   # Upcoming Events
   UpcomingEvents:

--- a/config.yml
+++ b/config.yml
@@ -89,9 +89,9 @@ params:
         collect and share detailed clinical and biological data from individuals with COVID-19.  The
         event will be open to the public, and is part of a continuing series focusing on
         data-related aspects of the scientific response to the pandemic.
-      register: https://register
-      agenda: https://agenda
-      sponsor: https://sponsor
+#      register: https://register
+#      agenda: https://agenda
+#      sponsor: https://sponsor
 
   # Past Events
   PastEvents:

--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ params:
   Name: "COVID-19"
   Subname: "Data Forum"
   Description: "COVID-19 Data Forum: A series of multidisciplinary, online meetings for topic experts to focus on data-related aspects of the scientific response to the pandemic."
-  Date: "May 14 2020"
+  Date: "Next event: Wed July 16 @ 9:00am PDT"
   Price: "" # If your event is free, just comment this line
   Venue: "Virtual Online"
   Address: ""
@@ -23,11 +23,14 @@ params:
   # Active sections on the website to deactivate comment out with '#'
   # you can also change order here and it will reflect on page
   Sections:
+    - promo
     - about
-    #- speakers
-    #- agenda
+    - events
     - committee
     - sponsors
+    #- schedule
+    #- speakers
+    #- agenda
     #- location
     #- schedule
     #- partners
@@ -36,14 +39,17 @@ params:
   # Titles which you can translate to other languages
   Titles:
     about: "About"
-    speakers: "Speakers"
+    events: "Events"
+    committee: "Organizing Committee"
+    sponsors: "Sponsors"
+    #promo: "Promo"
+    #contact: "Contact"
+    #speakers: "Speakers"
     #location: "Location"
     #agenda: "Agenda"
+    #events: "Events"
     #schedule: "Schedule"
-    sponsors: "Sponsors"
-    committee: "Organizing Committee"
     #partners: "Partners"
-    contact: "Contact"
 
   # The Call To Action button at the header,
   # If you don't want this, just remove the callToAction property.
@@ -53,14 +59,98 @@ params:
     text: "More Information"
     link: "mailto:covid-19-data-forum@r-consortium.org"
 
-  # List of Sponsors
-  Sponsors:
-    - name: "R Consortium"
-      logo: "/img/RConsortium_Horizontal_Pantone.svg"
-      url: "https://www.r-consortium.org"
-    - name: "Stanford Data Science Institute"
-      logo: "/img/stanford_data_science_institute.png"
-      url: "https://datascience.stanford.edu/"
+
+  # Promo box items
+  Promo:
+    - text: >
+        Interested in R and Medicine? Join us at the R/Medicine conference, August 27 - 29, 2020. »
+      actionText: "Learn more"
+      actionURL: "https://events.linuxfoundation.org/r-medicine/"
+
+  # Upcoming Events
+  UpcomingEvents:
+    - title: "Beyond case counts: Making COVID-19 clinical data available and useful"
+      date: "Thursday, July 16, 2020"
+      time: "16:00 UTC | 9am PDT | 12pm EDT | 5pm London | 6pm Paris | 12am Beijing"
+      description: >
+        COVID-19 is the first pandemic to occur in the age of open data. Public health agencies
+        around the world are releasing case counts to the public, and scientists are providing
+        analyses and forecasts in real-time. However, the content of this data has so far been
+        limited to simple metrics like cases, deaths, and hospitalizations at coarse geographic and
+        demographic scales. To drive the next-phase of COVID-19, scientists need access to
+        higher-dimensional patient-level data, so we can understand how the virus causes disease,
+        why are some more at risk than others, when and how is transmission occurring, what
+        therapeutics are more likely to work, and what healthcare resources are being used. But
+        sharing such data brings up tremendous challenges in terms of patient privacy and data
+        standardization. The COVID-19 Data Forum, a collaboration between Stanford University and
+        the R Consortium, is hosting the event "Beyond case counts: Making COVID-19 clinical data
+        available and useful" to push the conversation forward on these issues. The event will
+        include talks by representatives from international collaborative teams who are working to
+        collect and share detailed clinical and biological data from individuals with COVID-19.  The
+        event will be open to the public, and is part of a continuing series focusing on
+        data-related aspects of the scientific response to the pandemic.
+      register: https://register
+      agenda: https://agenda
+      sponsor: https://sponsor
+
+  # Past Events
+  PastEvents:
+    - title: "Introducing the COVID-19 Data Forum"
+      date: "Thursday, May 14, 2020"
+      time: "19:00 UTC | 12pm PDT | 3pm EDT | 8pm London | 9pm Paris | 3am Beijing"
+#      register: https://register
+#      sponsor: https://sponsor
+      description: |
+        The opening event of the COVID-19 Data Forum was held on May 14 2020 and attracted several
+        hundred attendees for a lively discussion of the current state of COVID-19 data and the
+        challenges researchers face.
+      agenda:
+        - talk: "Welcome and opening remarks"
+          speakerName: "Joseph Rickert"
+          speakerURL: "https://rstudio.com/speakers/joseph-rickert/"
+          affiliations:
+            - title: "Chair R Consortium Board of Directors"
+              organizationName: "R Consortium"
+              organizationURL: "https://r-consortium.org"
+          replay: "https://www.youtube.com/watch?v=6N1p99bLXjk"
+        - talk: "Modeling COVID-19 Spread and Control: Data Needs and Challenges"
+          speakerName: "Alison Hill"
+          speakerURL: "https://ped.fas.harvard.edu/people/alison-hill"
+          affiliations:
+            - title: "John Harvard Distinguished Science Fellow"
+              organizationName: "Harvard's Program for Evolutionary Dynamics"
+              organizationURL: "https://ped.fas.harvard.edu/"
+          replay: "https://youtu.be/6N1p99bLXjk?t=287"
+        - talk: "Collecting and Visualizing COVID-19 Case Count Data from Multiple Open Sources"
+          speakerName: "Ryan Hafen"
+          speakerURL: "https://ryanhafen.com/"
+          affiliations:
+            - title: "Data scientist consultant"
+              organizationName: "Preva Group"
+              organizationURL: "https://www.prevagroup.com/"
+            - title: "Adjunct Assistant Professor"
+              organizationName: "Purdue University"
+              organizationURL: "https://www.purdue.edu/"
+          replay: "https://youtu.be/6N1p99bLXjk?t=1249"
+        - talk: "Spatial and Space-Time Data on COVID-19"
+          speakerName: "Orhun Aydin"
+          speakerURL: "https://www.linkedin.com/in/orhunaydin/"
+          affiliations:
+            - title: "Researcher and Product Engineer"
+              organizationName: "ESRI"
+              organizationURL: "https://www.esri.com/en-us/home"
+            - title: "Lecturer"
+              organizationName: "University of Southern California"
+              organizationURL: "https://spatial.usc.edu/team-view/orhun-aydin/"
+          replay: "https://youtu.be/6N1p99bLXjk?t=2297"
+        - talk: "Data in the COVID-19 Pandemic"
+          speakerName: "Noam Ross"
+          speakerURL: "https://www.ecohealthalliance.org/personnel/dr-noam-ross"
+          affiliations:
+            - title: "Senior Research Scientist"
+              organizationName: "EcoHealth Alliance"
+              organizationURL: "https://www.ecohealthalliance.org/"
+          replay: "https://youtu.be/6N1p99bLXjk?t=3323"
 
   # List of Committee members
   Committee:
@@ -79,6 +169,20 @@ params:
     - name: "Chris Mentzel"
       jobtitle: "Executive Director, Stanford Data Science"
       url: "https://datascience.stanford.edu/people/chris-mentzel"
+    - name: "Alison Hill"
+      jobtitle: "John Harvard Distinguished Science Fellow, Harvard University"
+      url: "https://www.people.fas.harvard.edu/~alhill/"
+
+  # List of Sponsors
+  Sponsors:
+    - name: "R Consortium"
+      logo: "/img/RConsortium_Horizontal_Pantone.svg"
+      url: "https://www.r-consortium.org"
+    - name: "Stanford Data Science Institute"
+      logo: "/img/stanford_data_science_institute.png"
+      url: "https://datascience.stanford.edu/"
+
+## The following config options are unused.
 
   # List of Partners
   Partners:
@@ -120,12 +224,8 @@ params:
         href: "https://www.ecohealthalliance.org/personnel/dr-noam-ross"
         text: "Website"
 
-
   # The entire schedule
   Schedule:
-    - name: "Check-in / Breakfast"
-      time: "9h00"
-
     - name: "Linus Torvalds"
       photo: "/img/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -443,6 +443,42 @@ nav {
   font-size: 1.4em;
 }
 /* =============================================================================
+   EVENTS
+   ========================================================================== */
+.events-tbl {
+  padding: 20px;
+}
+.events-tbl table {
+  border-collapse: collapse;
+  font-size: 1em;
+}
+.events-tbl td, 
+.events-tbl th {
+  position: relative;
+  padding: 20px 30px;
+  font-size: 1.4em;
+  line-height: 1.4em;
+  text-align: left;
+}
+.events-tbl th {
+  padding: 5px 30px;
+  color: #2b2b2b;
+  font-size: 2em;
+  font-weight: bolder;
+}
+.events-tbl .event-date {
+  width: 150px;
+  text-align: center;
+}
+.event-title {
+  width: 250px;
+  font-size: 16px;
+}
+.event-description {
+  display: block;
+  font-size: 12px;
+}
+/* =============================================================================
    SCHEDULE
    ========================================================================== */
 .schedule-tbl {

--- a/themes/covid19-data-forum/layouts/partials/about.html
+++ b/themes/covid19-data-forum/layouts/partials/about.html
@@ -1,110 +1,66 @@
 <h2 class="section-title">{{ .titles.about }} the Forum</h2>
 
-<div style="border: 1px solid #fddd52; padding: 20px; margin-top: 20px; margin-bottom: 20px; background-color: #f4f4f4; border-radius: 4px; ">
-<p itemprop="description">COVID-19 Data Forum: A series of multidisciplinary, online meetings for topic experts to
-  focus on data-related aspects of the scientific response to the pandemic, including data access and sharing,
-  essential data resources for analysis, and how we can best support decision making. The webinars are public and all are welcome.
-</p>
-<!--
-<br><br>
-<p style="text-align: left;">The first online meeting was held on May 14, 2020</p>
-<p style="text-align: center;">
-  Public webinar, all welcome:
-  <br>
-  <br>
-
-  <a href="https://stanford.zoom.us/j/98394335515" target="_blank" style="color:#f5f5f5;background-color: #999; border: 1px solid #666;border-radius: 30px;text-decoration: none;padding: 10px; margin-top: 40px;">Join the Webinar</a>
-  <br>
-  <br>
-
-</p>
--->
+<div style="border: 1px solid #fddd52; padding: 20px 20px 0px; margin-top: 20px; margin-bottom: 20px; background-color: #f4f4f4; border-radius: 4px; ">
+<p itemprop="description">The COVID-19 Data Forum brings together experts working to collect and curate data needed to drive scientific research and formulate effective public health responses to the pandemic.</p>
 </div>
 
-<h4>More about the Event</h4>
-<p>The COVID-19 pandemic has challenged science and society to an unprecedented degree. Human lives and the future of our society depend on the response. That response, in turn, depends critically on data. This data must be as complete and accurate as possible; easily and flexibly accessible, and equipped to communicate effectively with decision-makers and the public.
-</p>
-<p>
-The COVID-19 Data Forum is a project to bring together those involved with relevant data in a series of multidisciplinary online meetings discussing current resources, needed enhancements, and the potential for co-operative efforts.
-</p>
-<p>
-The first meeting was a webinar featuring a series of related talks, which took place on<br>
-<b>May 14, 2020 at 19:00 UTC (12PM San Francisco,  8PM London, 5AM Sydney)</b>.
-</p>
-<p>
-Events will be a public, all welcome.  <!--Zoom address: <a href="https://stanford.zoom.us/j/98394335515" target="_blank">https://stanford.zoom.us/j/98394335515</a>-->
-</p>
-<p>
-This conference adheres to the Stanford Data Science's <a href="https://datascience.stanford.edu/about/about-institute/code-of-conduct" target="_blank">Code of Conduct policy</a>.
-</p>
+<p>The COVID-19 pandemic is challenging science and society to an unprecedented degree. Human lives
+and the future of our society are at stake. Containing the virus and flattening the curve" of the
+pandemic depend on mounting a strong, coordinated, scientifically-informed public health response
+which in turn ultimately depends on having complete and accurate data from multiple data
+sources.</p>
+<p>The <strong>COVID-19 Data Forum</strong> is an ongoing series of multidisciplinary webinars and
+online meetings for topic experts to discuss data-related aspects of the scientific response to the
+pandemic.  The Forum is a joint project of the <a href="https://r-consortium.org">R Consortium</a>
+and the <a href="https://datascience.stanford.edu/">Stanford Data Science Institute</a>. We host
+recurring topical webinars that are free and open to the public.</p>
 
-<h4>Details on the Forum</h4>
-<p>
-  The May 14, 2020 webinar will be followed by a series of private and public discussions, involving active participants in the wide range of disciplines concerned with COVID-19 related data. These discussions will also actively seek dialog with decision-makers and others relying on information from the data and from models or analysis based on it.
-</p>
-<p>
-  The Forum places particular emphasis on being open to all relevant interested groups and, with respect to computing,
-  to considering all useful tools, languages and environments.
-</p>
-<p>
-  We hope that the COVID-19 Data Forum discussions can usefully proceed through three stages of questions:
-</p>
-<p>
-  - Where are we now, with respect to resources and needs?<br>
-  - What immediate steps (e.g. in terms of sharing) would make improvements?<br>
-  - What potential projects for new tools, standards, or data models might be worth undertaking?<br>
-</p>
-<p>
-  At all stages, there are many specific topics that need discussion.  To sort them out, three kinds of activities are
-  useful categories:  <b>obtaining</b> the data; <b>using</b> the data; and <b>communicating</b> about the data.
-</p>
-<p>
-  <b>Obtaining Data.</b> The COVID-19 data challenges begin with just acquiring data of the range and quality needed.
-  A very wide range of data is needed, in three dimensions:  geographical, time and domain. Depending on the purpose,
-  data may be needed either very specifically local or at the widest global level. Both are challenging --- finding
-  reliable local sources and resolving hugely variable international ones, for example. Particularly on the global
-  (or even national) scale, variable quality will often be a challenge.
-</p>
-<p>
-  Timeliness of the data is clearly essential, particularly as public health regulations and other societal responses change.
-  But scientific models and analysis may also need to have data over a long time span.
-</p>
-<p>
-  The pandemic has touched our lives in many ways:  directly in our health but also in nearly all aspects of our economy
-  and society. As the world responds, data science will need to consider all these aspects, requiring data from the
-  microscopic level of the virus to the population data for epidemiology, social science, and economics.
-</p>
-<p>
-  <b>Using Data.</b>  The response to the COVID-19 pandemic from the Community continues to generate crucial data-based
-  results. Epidemiologists, public health experts, data scientists, and other researchers have produced a large number
-  of predictive models, interactive resource allocation applications, and disease tracking dashboards.
-</p>
-<p>
-  Moving ahead, it will be important to have easy, consistent access to the best data for all these efforts.
-  Co-operation and co-ordination among the teams involved can enhance the scope and help ensure that model results
-  and comparisons use consistent, well-defined data sources.
-</p>
-<p>
-  <b>Communicating Data.</b>  A key goal of the Data Forum is to improve communication between decision-makers
-  (in public health, government, and elsewhere) and the data science and general research community.
-  Many tools have been developed for visualizing and interacting with data.  It's important to understand how
-  these can be used and enhanced for the decision-making community.  We look forward to participation in our
-  meetings by interested members of this community.
-<p>
-<p>
-  Another important goal is to improve the information flow to the broader community, with emphasis on giving insight and
-  avoiding misdirection.
-</p>
+<p>The Forum places particular emphasis on being open to all relevant interested groups and
+including a wide range of expertise. With respect to computing, the Forum considers all useful
+tools, languages and environments. We hope that the COVID-19 Data Forum discussions can usefully
+proceed through three stages of questions:</p>
 
-<h4>Speakers</h4>
+<ul class="bulleted">
+<li>Where are we now, with respect to resources and needs?</li>
+<li>What immediate steps (e.g. in terms of sharing) would make improvements?</li>
+<li>What potential projects for new tools, standards, or data models might be worth
+undertaking?</li>
+</ul>
 
-<p>
-  Previous Speaker include: <br>
-  Orhun Aydin, Researcher and Product Engineer, ESRI<br>
-  Ryan Hafen, data scientist consultant with Preva Group, and adjunct assistant professor, Purdue University<br>
-  Alison L. Hill, Research Fellow and independent principal investigator at Harvard’s Program for Evolutionary Dynamics.<br>
-  Noam Ross, Senior Research Scientist, EcoHealth Alliance<br>
-</p>
+<p>At all stages, there are many specific topics that need discussion. To sort them out, three kinds
+of activities are useful categories: obtaining the data; using the data; and communicating about the
+data.</p>
 
-<!--<p>This is just a live demo, check our <a href="https://github.com/braziljs/conf-boilerplate" target="_blank">repository
-  on Github</a> for more details =D</p>-->
+<p><strong>Obtaining Data.</strong> COVID-19 data challenges begin with just acquiring data of the
+range and quality needed. A very wide range of data is needed, in three dimensions: geographical,
+time, and domain. Depending on the purpose, data may be needed either at very specific local levels
+or at the widest global level. Both are challenging --- finding reliable local sources and resolving
+hugely variable international ones, for example. Particularly on the global (or even national)
+scale, variable quality will often be a challenge. Timeliness of the data is clearly essential,
+particularly as public health regulations and other societal responses change. But scientific models
+and analysis may also need to have data over a long time span. The pandemic has touched our lives in
+many ways: directly in our health but also in nearly all aspects of our economy and society. As the
+world responds, data science will need to consider all these aspects, requiring data from the
+microscopic level of the virus to the population data for epidemiology, social science, and
+economics.</p>
+
+<p><strong>Using Data.</strong> The response to the COVID-19 pandemic from the scientific community
+continues to generate crucial data-based results. Epidemiologists, public health experts, data
+scientists, and other researchers have produced a large number of predictive models, interactive
+resource allocation applications, and disease tracking dashboards. Moving ahead, it will be
+important to have easy, consistent access to the best data for all these efforts. Co-operation and
+co-ordination among the teams involved can enhance the scope and help ensure that model results and
+comparisons use consistent, well-defined data sources.</p>
+
+<p><strong>Communicating Data.</strong> A key goal of the Data Forum is to improve communication
+between decision-makers (in public health, government, and elsewhere) and the data science and
+general research community. Many tools have been developed for visualizing and interacting with
+data. It's important to understand how these can be used and enhanced for the decision-making
+community. We look forward to participation in our meetings by interested members of this community.
+Another important goal is to improve the information flow to the broader community, with emphasis on
+giving insight and avoiding misdirection.</p>
+
+<p>All events hosted by the Forum adhere to <a
+href="https://datascience.stanford.edu/about/about-institute/code-of-conduct">Stanford Data
+Science's Code of Conduct policy</a></p>.
+

--- a/themes/covid19-data-forum/layouts/partials/events.html
+++ b/themes/covid19-data-forum/layouts/partials/events.html
@@ -1,0 +1,91 @@
+<h2 class="section-title">{{ .titles.schedule }}</h2>
+
+{{ if ne .upcomingevents nil }}
+
+  <div class="events">
+
+    <h3>Upcoming events</h3>
+
+    <div class="intro">
+      <p>Please join us for our second public, virtual event, focused on <strong>efforts to improve
+      accessibility of patient-level data for COVID-19</strong>.  A link to register and more details
+      on our speakers will be available soon.</p>
+    </div>
+
+    {{ range $slot := .upcomingevents }}
+
+      <div class="event">
+        <h4 class="title">{{ .title }}</h4>
+        <div class="date-and-time">
+          <p class="date">{{ .date }}</p>
+          <p class="time">{{ .time }}</p>
+        </div>
+        <p class="description">{{ .description }}</p>
+      </div>
+
+    {{ end }}
+  </div>
+{{ end }}
+
+{{ if ne .pastevents nil }}
+  <div class="events">
+
+    <h3>Past events</h3>
+
+    <div class="intro">
+      <p>We record our events, and will make them available for replay shortly after they conclude.
+    </div>
+
+    {{ range $slot := .pastevents }}
+
+      <div class="event">
+        <h4 class="title">{{ .title }}</h4>
+
+        <div class="date-and-time">
+          <p class="date">{{ .date }}</p>
+          <p class="time">{{ .time }}</p>
+        </div>
+
+        {{ if or (ne .register nil) (ne .sponsor nil) }}
+
+          <div class="actions">
+            {{ if ne .register nil }}
+              <a href="{{ .register }}" target="_blank" class="body_button">Register</a>
+            {{ end }}
+
+            {{ if ne .sponsor nil }}
+              <a href="{{ .sponsor }}" target="_blank" class="body_button">Sponsor</a>
+            {{ end }}
+          </div>
+        {{ end }}
+
+        <div class="description">
+          <p>{{ .description }}</p>
+        </div>
+
+        {{ if ne .agenda nil }}
+            <div class="agenda">
+              <ul class="bulleted">
+                {{ range $talks := .agenda }}
+                  <li><strong><a href="{{ .speakerURL }}" target="_blank">{{ .speakerName }}</a>: {{ .talk }}</strong>
+                  {{ if ne .replay nil }}
+                    (<a href="{{ .replay }}" target="_blank">replay</a>)
+                  {{ end }}
+
+                  <ul class="affiliations">
+                    {{ range $affiliations := .affiliations }}
+                      <li>{{ .title }}, <a href="{{ .organizationURL }}" target="_blank">{{ .organizationName }}</a></li>
+                    {{ end }}
+
+                  </ul>
+                  </li>
+
+                {{ end }}
+              </ul>
+            </div>
+          </div>
+        {{ end }}
+    {{ end }}
+  </div>
+{{ end }}
+

--- a/themes/covid19-data-forum/layouts/partials/events.html
+++ b/themes/covid19-data-forum/layouts/partials/events.html
@@ -16,13 +16,51 @@
 
       <div class="event">
         <h4 class="title">{{ .title }}</h4>
+
         <div class="date-and-time">
           <p class="date">{{ .date }}</p>
           <p class="time">{{ .time }}</p>
         </div>
-        <p class="description">{{ .description }}</p>
-      </div>
 
+        {{ if or (ne .register nil) (ne .sponsor nil) }}
+
+          <div class="actions">
+            {{ if ne .register nil }}
+              <a href="{{ .register }}" target="_blank" class="body_button">Register</a>
+            {{ end }}
+
+            {{ if ne .sponsor nil }}
+              <a href="{{ .sponsor }}" target="_blank" class="body_button">Sponsor</a>
+            {{ end }}
+          </div>
+        {{ end }}
+
+        <div class="description">
+          <p>{{ .description }}</p>
+        </div>
+
+        {{ if ne .agenda nil }}
+            <div class="agenda">
+              <ul class="bulleted">
+                {{ range $talks := .agenda }}
+                  <li><strong><a href="{{ .speakerURL }}" target="_blank">{{ .speakerName }}</a>: {{ .talk }}</strong>
+                  {{ if ne .replay nil }}
+                    (<a href="{{ .replay }}" target="_blank">replay</a>)
+                  {{ end }}
+
+                  <ul class="affiliations">
+                    {{ range $affiliations := .affiliations }}
+                      <li>{{ .title }}, <a href="{{ .organizationURL }}" target="_blank">{{ .organizationName }}</a></li>
+                    {{ end }}
+
+                  </ul>
+                  </li>
+
+                {{ end }}
+              </ul>
+            </div>
+          </div>
+        {{ end }}
     {{ end }}
   </div>
 {{ end }}

--- a/themes/covid19-data-forum/layouts/partials/promo.html
+++ b/themes/covid19-data-forum/layouts/partials/promo.html
@@ -1,0 +1,8 @@
+{{ if ne .promo nil }}
+  {{ range $promo := .promo }}
+    <div class="item">
+      <p><a href="{{ .actionURL }}" target="_blank">{{ .text }}</a></p>
+    </div>
+  {{ end }}
+{{ end }}
+

--- a/themes/covid19-data-forum/layouts/partials/schedule.html
+++ b/themes/covid19-data-forum/layouts/partials/schedule.html
@@ -2,6 +2,22 @@
 
 <p>The first COVID-19 Data Forum will have two parts, the main public webinar open to all and an invited workshop.
   We will evaluate our ability to scale the workshop to more people for future meetings.</p>
+
+<h3>Upcoming events</h3>
+
+<p>Please join us for our second public, virtual event, focused on <strong>efforts to improve
+accessibility of patient-level data for COVID-19</strong>.  A link to register and more details on
+our speakers will be available soon.</p>
+
+<h4>Beyond case counts: Making COVID-19 clinical data available and useful</h4>
+
+<strong>Thurs July 16 2020, 16:00 UTC</strong>
+
+
+
+<h3>Prior events</h3>
+
+
 <div class="schedule-tbl">
   <table>
     <thead>

--- a/themes/covid19-data-forum/layouts/partials/sponsors.html
+++ b/themes/covid19-data-forum/layouts/partials/sponsors.html
@@ -1,6 +1,8 @@
 <h2 class="section-title">{{ .titles.sponsors }}</h2>
 <p>
-  The COVID-19 Data Forum is jointly sponsored by the <a href="https://r-consortium.org">R Consortium</a> and the <a href="https://datascience.stanford.edu/programs/covid-19">Stanford Data Science Institute</a>.
+  The COVID-19 Data Forum is jointly sponsored by the <a href="https://r-consortium.org"
+  target="_blank">R Consortium</a> and the <a
+  href="https://datascience.stanford.edu/programs/covid-19" target="_blank">Stanford Data Science Institute</a>.
 </p>
 <br>
 

--- a/themes/covid19-data-forum/static/css/main.css
+++ b/themes/covid19-data-forum/static/css/main.css
@@ -313,6 +313,22 @@ p {
   position: relative;
   top: -1px;
 }
+.content ul {
+  list-style: none;
+  font-size: 16px;
+  line-height: 1.6em;
+  margin-left: 0;
+  padding-left: 0;
+}
+.content .bulleted li {
+  padding: 0 0 1em 2em;
+  text-indent: -1em;
+}
+.content .bulleted li:before {
+  content: "»";
+  padding-right: 10px;
+}
+
 /* =============================================================================
    NAVIGATION
    ========================================================================== */
@@ -402,6 +418,31 @@ nav {
   transition: all 0.3s ease-out;
 }
 /* =============================================================================
+   PROMO
+   ========================================================================== */
+section.promo {
+  padding-top: 0px;
+  border: 1px solid #fddd52;
+  margin: 0px -20px 50px;
+  border-radius: 4px;
+  background-color: #2b2b2b;
+  font-size: 1.4em;
+}
+.promo .item p {
+  margin-bottom: 0px;
+}
+.promo .item a {
+  padding: 10px 19px;
+  text-decoration: none;
+  display: block;
+  height: 100%;
+}
+.promo .item a:hover {
+  text-decoration: none;
+  background-color: #1b1b1b;
+  border-radius: 4px;
+}
+/* =============================================================================
    ABOUT
    ========================================================================== */
 .about {
@@ -441,6 +482,61 @@ nav {
 }
 .speakers-item p {
   font-size: 1.4em;
+}
+/* =============================================================================
+   EVENTS
+   ========================================================================== */
+.events {
+}
+.events .intro {
+  padding-top: 20px;
+  font-style: italic;
+}
+.event {
+  padding: 40px 0px;
+}
+.event .title {
+  font-size: 2.8em;
+  font-weight: bold;
+  text-align: center;
+}
+.event .date-and-time {
+  padding: 20px 0px;
+}
+.event .date {
+  color: #333;
+  font-size: 2em;
+  font-weight: bold;
+  text-align: center;
+  margin: 0px;
+  padding: 0px;
+}
+.event .time {
+  color: #333;
+  text-align: center;
+  margin: 0px;
+  padding: 0px;
+}
+.event .description {
+}
+.event .actions {
+  text-align: center;
+  padding: 20px;
+}
+.event .actions a {
+  font-weight: bold;
+  margin: 0px 10px;
+  padding: 10px 15px;
+}
+.event .agenda {
+  padding: 10px 20px 0;
+}
+.event .agenda .affiliations li {
+  padding-bottom: 0px;
+}
+.event .agenda .affiliations li:before {
+  content: "-";
+  padding-right: 10px;
 }
 /* =============================================================================
    SCHEDULE
@@ -554,6 +650,9 @@ nav {
     -ms-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
+  }
+  section.promo {
+    margin: 20px 0;
   }
   .about {
     margin: 0;


### PR DESCRIPTION
This commit adds support for multiple events, with agendas and replays. It also adds a promo to the
top, and a variety of other improvments that will improve long-term maintainability.

It also contains updates to the upcoming event.

Signed-off-by: Brian Warner <brian@bdwarner.com>